### PR TITLE
feat: Join multiple description fields when importing data

### DIFF
--- a/src/lib/useImportTransactions.ts
+++ b/src/lib/useImportTransactions.ts
@@ -54,10 +54,13 @@ const useImportTransactions = (account: Account) => {
         }) as string[][];
 
         const dateIndex = preset.fields.indexOf('Date');
-        const descriptionIndex = preset.fields.indexOf('Description');
 
         const transactions = records.map((record) => {
-          const description = record[descriptionIndex] || '';
+          const description = getMultipleFieldValues(
+            record,
+            preset,
+            'Description',
+          );
           const amount = parseNumericField(record, preset, 'Amount');
           const fee = parseNumericField(record, preset, 'Fee');
           const deposit = parseNumericField(record, preset, 'Deposit');
@@ -147,4 +150,27 @@ const parseDate = (dateStr: string, dateFormat: string) => {
       date.getMilliseconds(),
     ),
   );
+};
+
+const getMultipleFieldValues = (
+  record: string[],
+  preset: CSVImportPreset,
+  fieldName: CSVImportField,
+  concatString = '; ',
+): string => {
+  const fieldNameIndexes = preset.fields
+    .map((field, index) => (field === fieldName ? index : false))
+    .filter((field) => field) as number[];
+
+  const fieldValues: string[] = [];
+
+  if (fieldNameIndexes.length > 0) {
+    fieldNameIndexes.forEach((fieldNameIndex) => {
+      if (record[fieldNameIndex]?.trim() !== '') {
+        fieldValues.push(record[fieldNameIndex]);
+      }
+    });
+  }
+
+  return fieldValues.join(concatString);
 };


### PR DESCRIPTION
This change enables merge of multiple description fields during import account data.

When input data has multiple columns with description-like data, this should merge those columns into one.

Automatic category assignment works better after that.